### PR TITLE
Add start_rpc_listeners() to MechanismDriver

### DIFF
--- a/neutron_lib/plugins/ml2/api.py
+++ b/neutron_lib/plugins/ml2/api.py
@@ -76,6 +76,17 @@ class MechanismDriver(object, metaclass=abc.ABCMeta):
         called prior to this method being called.
         """
 
+    def start_rpc_listeners(self):
+        """Start RPC listeners.
+
+        Create and start RPC listeners required by this driver. To be used in
+        cases where the driver has an agent that requires extra RPC methods to
+        acquire some data. It is preferred to initialize RPC listeners here
+        instead of in initialize() to support the split between RPC and API
+        workers. It works similar to NeutronPluginBaseV2.start_rpc_listeners().
+        """
+        return []
+
     def create_network_precommit(self, context):
         """Allocate resources for a new network.
 

--- a/releasenotes/notes/allow-ml2-plugins-to-start-own-rpc-listeners-54f05910ac3f336a.yaml
+++ b/releasenotes/notes/allow-ml2-plugins-to-start-own-rpc-listeners-54f05910ac3f336a.yaml
@@ -1,0 +1,7 @@
+---
+other:
+  - |
+    MechanismDrivers can now start their own RPC listeners by implementing
+    start_rpc_listeners(). It is preferred to use this method instead of
+    initialize() for this task to support the split between RPC and
+    API workers.


### PR DESCRIPTION
This method will allow MechanismDrivers to start their own RPC listeners, if they require some, e.g. for communication between the driver and a custom agent. It is added as an alternative to create the backends in initialize(), as in cases where a driver is split up into the API and RPC part we want to make sure these backends are only started in the RPC part of neutron.

start_rpc_listeners() is modeled after
NeutronPluginBaseV2.start_rpc_listeners() and will be called as part of start_rpc_listeners() of the Ml2Plugin.

Change-Id: I5c50305bd3273318a1cdf393bbda9d33bdd91e4d
Partial-Bug: #2065198

---
This is a backport from the patch that was merged upstream here: https://review.opendev.org/c/openstack/neutron-lib/+/919589