### PR TITLE
[backport] vpnaas: add support for AES CTR

### DIFF
--- a/api-ref/source/v2/parameters.yaml
+++ b/api-ref/source/v2/parameters.yaml
@@ -3049,7 +3049,8 @@ encapsulation_mode:
 encryption_algorithm:
   description: |
     The encryption algorithm. A valid value is
-    ``3des``, ``aes-128``, ``aes-192``, ``aes-256``. Additional values for AES
+    ``3des``, ``aes-128``, ``aes-192``, ``aes-256``, ``aes-128-ctr``,
+    ``aes-192-ctr``, ``aes-256-ctr``. Additional values for AES
     CCM and GCM modes are defined (e.g. ``aes-256-ccm-16``, ``aes-256-gcm-16``)
     for all combinations of key length 128, 192, 256 bits and ICV length
     8, 12, 16 octets.

--- a/neutron_lib/api/definitions/__init__.py
+++ b/neutron_lib/api/definitions/__init__.py
@@ -163,6 +163,7 @@ from neutron_lib.api.definitions import vlan_filter
 from neutron_lib.api.definitions import vlantransparent
 from neutron_lib.api.definitions import vpn
 from neutron_lib.api.definitions import vpn_aes_ccm_gcm
+from neutron_lib.api.definitions import vpn_aes_ctr
 from neutron_lib.api.definitions import vpn_endpoint_groups
 from neutron_lib.api.definitions import vpn_flavors
 
@@ -320,6 +321,7 @@ _ALL_API_DEFINITIONS = {
     vlantransparent,
     vpn,
     vpn_aes_ccm_gcm,
+    vpn_aes_ctr,
     vpn_endpoint_groups,
     vpn_flavors,
 }

--- a/neutron_lib/api/definitions/vpn.py
+++ b/neutron_lib/api/definitions/vpn.py
@@ -28,6 +28,9 @@ IPSEC_POLICIES = 'ipsecpolicies'
 IKE_POLICY = 'ikepolicy'
 IKE_POLICIES = 'ikepolicies'
 
+# Parameter constants
+ENCRYPTION_ALGORITHM = 'encryption_algorithm'
+
 # VPN initiator constants
 VPN_INITIATOR_BI_DIRECTIONAL = 'bi-directional'
 VPN_INITIATOR_RESPONSE_ONLY = 'response-only'
@@ -374,11 +377,12 @@ RESOURCE_ATTRIBUTE_MAP = {
             'default': VPN_AUTH_ALGORITHM_SHA1,
             'validate': {'type:values': VPN_SUPPORTED_AUTH_ALGORITHMS},
             'is_visible': True},
-        'encryption_algorithm': {
+        ENCRYPTION_ALGORITHM: {
             'allow_post': True,
             'allow_put': True,
             'default': VPN_ENCRYPTION_ALGORITHM_AES_128,
-            'validate': {'type:values': VPN_SUPPORTED_ENCRYPTION_ALGORITHMS},
+            'validate': {
+                'type:values': VPN_SUPPORTED_ENCRYPTION_ALGORITHMS},
             'is_visible': True},
         'encapsulation_mode': {
             'allow_post': True,
@@ -425,10 +429,11 @@ RESOURCE_ATTRIBUTE_MAP = {
             'default': VPN_AUTH_ALGORITHM_SHA1,
             'validate': {'type:values': VPN_SUPPORTED_AUTH_ALGORITHMS},
             'is_visible': True},
-        'encryption_algorithm': {
+        ENCRYPTION_ALGORITHM: {
             'allow_post': True, 'allow_put': True,
             'default': VPN_ENCRYPTION_ALGORITHM_AES_128,
-            'validate': {'type:values': VPN_SUPPORTED_ENCRYPTION_ALGORITHMS},
+            'validate': {
+                'type:values': VPN_SUPPORTED_ENCRYPTION_ALGORITHMS},
             'is_visible': True},
         'phase1_negotiation_mode': {
             'allow_post': True, 'allow_put': True,

--- a/neutron_lib/api/definitions/vpn_aes_ctr.py
+++ b/neutron_lib/api/definitions/vpn_aes_ctr.py
@@ -1,0 +1,61 @@
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from neutron_lib.api.definitions import vpn
+
+
+ALIAS = 'vpn-aes-ctr'
+IS_SHIM_EXTENSION = True
+IS_STANDARD_ATTR_EXTENSION = False
+NAME = 'VPN support for AES CTR mode'
+DESCRIPTION = 'Add AES CTR choices for encryption algorithm'
+UPDATED_TIMESTAMP = '2024-01-09T09:00:00-00:00'
+SUB_RESOURCE_ATTRIBUTE_MAP = {}
+ACTION_MAP = {}
+REQUIRED_EXTENSIONS = [vpn.ALIAS]
+OPTIONAL_EXTENSIONS = []
+ACTION_STATUS = {}
+
+# Additional VPN encryption algorithm constants
+VPN_ENCRYPTION_ALGORITHM_AES_128_CTR = 'aes-128-ctr'
+VPN_ENCRYPTION_ALGORITHM_AES_192_CTR = 'aes-192-ctr'
+VPN_ENCRYPTION_ALGORITHM_AES_256_CTR = 'aes-256-ctr'
+
+VPN_SUPPORTED_ENCRYPTION_ALGORITHMS_WITH_CTR = (
+    vpn.VPN_SUPPORTED_ENCRYPTION_ALGORITHMS + [
+        VPN_ENCRYPTION_ALGORITHM_AES_128_CTR,
+        VPN_ENCRYPTION_ALGORITHM_AES_192_CTR,
+        VPN_ENCRYPTION_ALGORITHM_AES_256_CTR,
+    ]
+)
+
+
+RESOURCE_ATTRIBUTE_MAP = {
+    vpn.IKE_POLICIES: {
+        vpn.ENCRYPTION_ALGORITHM: {
+            'allow_post': True,
+            'allow_put': True,
+            'default': vpn.VPN_ENCRYPTION_ALGORITHM_AES_128,
+            'validate': {
+                'type:values': VPN_SUPPORTED_ENCRYPTION_ALGORITHMS_WITH_CTR},
+            'is_visible': True},
+    },
+    vpn.IPSEC_POLICIES: {
+        vpn.ENCRYPTION_ALGORITHM: {
+            'allow_post': True,
+            'allow_put': True,
+            'default': vpn.VPN_ENCRYPTION_ALGORITHM_AES_128,
+            'validate': {
+                'type:values': VPN_SUPPORTED_ENCRYPTION_ALGORITHMS_WITH_CTR},
+            'is_visible': True},
+    },
+}

--- a/releasenotes/notes/add-vpnaas-ciphers-6c1dffbc2cdc3225.yaml
+++ b/releasenotes/notes/add-vpnaas-ciphers-6c1dffbc2cdc3225.yaml
@@ -3,6 +3,7 @@ features:
   - |
     Added support for more ciphers to the neutron-vpnaas API.
     Added encryption algorithms (AES CCM and AES GCM modes for 128/192/256
-    bit keys and 8/12/16 octet ICVs, e.g. aes-256-ccm-16),
+    bit keys and 8/12/16 octet ICVs, e.g. aes-256-ccm-16, and AES CTR modes
+    for 128/192/256 bit keys, e.g. aes-256-ctr),
     authentication algorithms (AES-XCBC, AES-CMAC) and PFS choices
     (Diffie Hellman groups 15 to 31).


### PR DESCRIPTION
Additional choices for encryption algorithms in vpnaas policies for AES Counter Mode (AES-CTR).

Related-Bug: #1938284
Change-Id: Icda2da71135065a1192954f33943b9ee225c5cf4