### PR TITLE
Enforce policy on subnetpool address_scope_id

### DIFF
--- a/neutron_lib/api/definitions/address_scope.py
+++ b/neutron_lib/api/definitions/address_scope.py
@@ -78,7 +78,9 @@ RESOURCE_ATTRIBUTE_MAP = {
                            'validate': {'type:uuid_or_none': None},
                            'is_filter': True,
                            'is_sort_key': True,
-                           'is_visible': True}
+                           'is_visible': True,
+                           'required_by_policy': False,
+                           'enforce_policy': True}
     },
     'networks': {
         IPV4_ADDRESS_SCOPE: {'allow_post': False,


### PR DESCRIPTION
We want to have more fine-grained control on who can set an address scope on a subnet pool.

Change-Id: I3d1ab29e8cde163ea4d47072683790b06609e8c1